### PR TITLE
Redirect Release Notes

### DIFF
--- a/engine/download.html
+++ b/engine/download.html
@@ -713,7 +713,7 @@
 					<i class="bi bi-download text-white me-2"></i>Download
 				</a>
 				<a class="fw-semibold btn btn-danger btn-lg d-flex align-items-center justify-content-center"
-					href="/engine/notes">
+					href="https://github.com/armory3d/armory/issues?q=merged%3A2024-09-09..2024-12-02+">
 					<i class="bi bi-megaphone text-white me-2"></i>Release Notes
 				</a>
 			</div>


### PR DESCRIPTION
This directs the release notes button to the actual Github merges done since the last release. 

The old link directs to an outdated page, that is tricky to update (lots of different parts of the file have to be updated, overall finicky)

Bizow suggested to take everything down of the website, that is unmaintained. 
I agree 🕊️ 